### PR TITLE
Adding Encryption to Archive using OpenSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ The Secret Key used to connect to your Minio server.
 #### `MINIO_BUCKET=backups`
 The Minio bucket you wish to store your backup in.
 
+#### `ENCRYPTION_KEY`
+(Optional) The OpenSSL symmetric key to protect the archive with.  Should be sufficiently long to prevent dictionary based attacks.
+
 ### `DATE_FORMAT=+%Y-%m-%d`
 The date format you would like to use when naming your backup files. Files are named `$DB-$DATE.archive`.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ to maintain a frequent backup of your critical data with minimal fuss.
 * Dumps a single MongoDB database to an S3 bucket
 * Lightweight and short lived
 * Simple and readable implementation
+* Optional encryption for archive file
 
 ## Example
 ```sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,10 @@ ARCHIVE="${MINIO_BUCKET}/${DB}-$(date $DATE_FORMAT).archive"
 echo "Dumping $DB to $ARCHIVE"
 echo "> mongodump $ARGS -d $DB"
 
-mongodump $ARGS -d "$DB" --archive | mc pipe "mongodb/$ARCHIVE" || { echo "Backup failed"; mc rm "mongodb/$ARCHIVE"; exit 1; }
+if [ "${ARCHIVE_KEY}"];
+then mongodump $ARGS -d "$DB" --archive | openssl enc -aes-256-cbc -e -k "${ARCHIVE_KEY}"  | mc pipe "mongodb/$ARCHIVE" || { echo "Backup failed"; mc rm "mongodb/$ARCHIVE"; exit 1; }
+else mongodump $ARGS -d "$DB" --archive | mc pipe "mongodb/$ARCHIVE" || { echo "Backup failed"; mc rm "mongodb/$ARCHIVE"; exit 1; }
+fi
+    
 
 echo "Backup complete"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ echo "Dumping $DB to $ARCHIVE"
 echo "> mongodump $ARGS -d $DB"
 
 if [ "${ENCRYPTION_KEY}"];
-then mongodump $ARGS -d "$DB" --archive | openssl enc -aes-256-cbc -e -k "${ARCHIVE_KEY}"  | mc pipe "mongodb/$ARCHIVE" || { echo "Backup failed"; mc rm "mongodb/$ARCHIVE"; exit 1; }
+then mongodump $ARGS -d "$DB" --archive | openssl enc -aes-256-cbc -e -k "${ENCRYPTION_KEY}"  | mc pipe "mongodb/$ARCHIVE" || { echo "Backup failed"; mc rm "mongodb/$ARCHIVE"; exit 1; }
 else mongodump $ARGS -d "$DB" --archive | mc pipe "mongodb/$ARCHIVE" || { echo "Backup failed"; mc rm "mongodb/$ARCHIVE"; exit 1; }
 fi
     

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ ARCHIVE="${MINIO_BUCKET}/${DB}-$(date $DATE_FORMAT).archive"
 echo "Dumping $DB to $ARCHIVE"
 echo "> mongodump $ARGS -d $DB"
 
-if [ "${ARCHIVE_KEY}"];
+if [ "${ENCRYPTION_KEY}"];
 then mongodump $ARGS -d "$DB" --archive | openssl enc -aes-256-cbc -e -k "${ARCHIVE_KEY}"  | mc pipe "mongodb/$ARCHIVE" || { echo "Backup failed"; mc rm "mongodb/$ARCHIVE"; exit 1; }
 else mongodump $ARGS -d "$DB" --archive | mc pipe "mongodb/$ARCHIVE" || { echo "Backup failed"; mc rm "mongodb/$ARCHIVE"; exit 1; }
 fi


### PR DESCRIPTION
This can be added by simply specifying the Environment Variable ENCRYPTION_KEY, otherwise no encryption is attempted.  This is a fairly low impact to the whole project, but is necessary for use at my organization as we require all backups to be encrypted. 